### PR TITLE
Add validations for task_name in Todo model and implement unit tests

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,7 +1,8 @@
 from django.db import models
+from django.core.validators import MinLengthValidator
 
 class Todo(models.Model):
-    task_name=models.CharField(max_length=50)
+    task_name=models.CharField(max_length=50, unique=True, null=False, validators=[MinLengthValidator(3)])
     task_description=models.TextField(null=True, blank=True)
     is_completed=models.BooleanField(default=False)
 

--- a/app/tests.py
+++ b/app/tests.py
@@ -1,3 +1,124 @@
 from django.test import TestCase
+from django.core.exceptions import ValidationError
+from django.db.utils import IntegrityError
+from django.contrib import admin
+from .models import Todo
 
+class TestTodoModel(TestCase):
 
+    def test_create_todo(self):
+        self.todo = Todo.objects.create(
+            task_name='Task',
+            task_description='Description',
+            is_completed=True
+        )
+
+        self.todo.full_clean()
+        self.assertEqual(self.todo.task_name, 'Task')
+        self.assertEqual(self.todo.task_description, 'Description')
+        self.assertTrue(self.todo.is_completed)
+    
+    def test_create_todo_with_task_name_blank(self):
+        self.todo = Todo.objects.create(
+            task_name='',
+            task_description='Description',
+            is_completed=True
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            self.todo.full_clean()
+        self.assertIn('This field cannot be blank.', context.exception.message_dict['task_name'])
+    
+    def test_create_todo_with_none_task_name(self):
+        with self.assertRaises(IntegrityError) as context:
+            self.todo = Todo.objects.create(
+                task_name=None,
+                task_description='Description',
+                is_completed=True
+            )
+        self.assertIn('NOT NULL constraint failed', str(context.exception))
+        self.assertIn('app_todo.task_name', str(context.exception))
+
+    def test_create_todo_with_without_task_name(self):
+        self.todo = Todo.objects.create(
+            task_description='Description',
+            is_completed=True
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            self.todo.full_clean()
+        self.assertIn('This field cannot be blank.', context.exception.message_dict['task_name'])
+
+    def test_create_todo_with_shorter_task_name_length(self):
+        self.todo = Todo.objects.create(
+            task_name='T',
+            task_description='Description',
+            is_completed=True
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            self.todo.full_clean()
+        self.assertIn('Ensure this value has at least 3 characters (it has 1).', context.exception.message_dict['task_name'])
+    
+    def test_create_todo_with_longer_task_name_length(self):
+        self.todo = Todo.objects.create(
+            task_name='Title: The task for with the length greater than 50',
+            task_description='Description',
+            is_completed=True
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            self.todo.full_clean()
+        self.assertIn('Ensure this value has at most 50 characters (it has 51).', context.exception.message_dict['task_name'])
+    
+    def test_create_todo_with_task_name_already_exist(self):
+        Todo.objects.create(
+            task_name='Task',
+            task_description='Description',
+            is_completed=True
+        )
+
+        self.todo = Todo.objects.create(
+            task_name='Task',
+            task_description='',
+            is_completed=False
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            self.todo.full_clean()
+        self.assertIn('Todo with this Task name already exists.', context.exception.message_dict['task_name'])
+
+    def test_create_todo_without_description(self):
+        self.todo = Todo.objects.create(
+            task_name='Task',
+            is_completed=False
+        )
+
+        self.todo.full_clean()
+        self.assertEqual(self.todo.task_name, 'Task')
+        self.assertIsNone(self.todo.task_description)
+        self.assertFalse(self.todo.is_completed)
+
+    def test_create_todo_without_is_completed(self):
+        self.todo = Todo.objects.create(
+            task_name='Task',
+            task_description='Description',
+        )
+
+        self.todo.full_clean()
+        self.assertEqual(self.todo.task_name, 'Task')
+        self.assertEqual(self.todo.task_description, 'Description')
+        self.assertFalse(self.todo.is_completed)
+
+class TestTodoAdmin(TestCase):
+    def setUp(self):
+        self.todo_admin = admin.site._registry[Todo]
+
+    def test_display_list(self):
+        self.assertEqual(self.todo_admin.list_display, ('id', 'task_name', 'is_completed'))
+    
+    def test_list_filter(self):
+        self.assertEqual(self.todo_admin.list_filter, ['is_completed'])
+    
+    def test_search_fields(self):
+        self.assertEqual(self.todo_admin.search_fields, ('task_name', 'task_description'))


### PR DESCRIPTION
### PR Description
This PR adds validation rules to the task_name field in the Todo model to improve data integrity and user input quality.

**Summary**
- Set max_length=50 on task_name to prevent longer task names.
- Set unique=True on task_name to prevent duplicate tasks creation.
- Set null=False on task_name to prevent storing NULL values in the database.
- Added MinLengthValidator(3) to enforce a minimum length of 3 characters for the task_name field.

These validations help ensure that all tasks have meaningful names and prevent empty or too-short task entries.

**Testing**
By clicking the `Add todo` on todo list page, the user will visit the add todo page, where he have to submit the form to create a new todo item. Form will submit successfully if the following validation are fullfilled other it will show errors on the top of form.
1) User must enter the task name
2) User must enter the task name longer than 3 characters
3) User must enter the unique task name (duplicate task names not allowed).