### PR TITLE
Add filtering to Todo list view with default display of completed tasks

### DIFF
--- a/app/templates/todo/list.html
+++ b/app/templates/todo/list.html
@@ -18,6 +18,15 @@
         <a href="{% url 'todo_create' %}">Add Todo</a>
     <div>
     <hr>
+    <form action="{% url 'todo_list' %}" method="get">
+        <select name="status">
+            <option value="all">All</option>
+            <option value="completed" selected>Completed</option>
+            <option value="not_completed">Not Completed</option>
+        </select>
+        <button type="submit">Filter results</button>
+    </form>
+    <hr>
     <div>Number of Todos found: {{ todos | length }}</div>
     <hr>
     {% if todos %}

--- a/app/tests.py
+++ b/app/tests.py
@@ -126,23 +126,51 @@ class TestTodoAdmin(TestCase):
 
 class TestTodoListViews(TestCase):
     def setUp(self):
-        self.todo1 = Todo.objects.create(
+        self.not_completed_task = Todo.objects.create(
             task_name='Task 1',
             task_description='Task 1 description',
             is_completed=False
         )
-        self.todo2 = Todo.objects.create(
+        self.completed_task = Todo.objects.create(
             task_name='Task 2',
             task_description='Task 2 description',
             is_completed=True
         )
 
-    def test_todo_list_view(self):
+    def test_todo_list_view_without_filter(self):
         response = self.client.get(reverse('todo_list'))
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, self.todo1)
-        self.assertContains(response, self.todo2)
+        self.assertNotContains(response, self.not_completed_task)
+        self.assertContains(response, self.completed_task)
+
+    def test_todo_list_view_with_status_completed(self):
+        response = self.client.get(reverse('todo_list'), data={'status': 'completed'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, self.not_completed_task)
+        self.assertContains(response, self.completed_task)
+
+    def test_todo_list_view_with_status_not_completed(self):
+        response = self.client.get(reverse('todo_list'), data={'status': 'not_completed'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.not_completed_task)
+        self.assertNotContains(response, self.completed_task)
+
+    def test_todo_list_view_with_status_all(self):
+        response = self.client.get(reverse('todo_list'), data={'status': 'all'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.not_completed_task)
+        self.assertContains(response, self.completed_task)
+
+    def test_todo_list_view_with_invalid_status(self):
+        response = self.client.get(reverse('todo_list'), data={'status': 'xyz'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, self.not_completed_task)
+        self.assertContains(response, self.completed_task)
 
 class TestTodoCreateViews(TestCase):
     def setUp(self):

--- a/app/views.py
+++ b/app/views.py
@@ -7,6 +7,16 @@ class TodoList(ListView):
     template_name='todo/list.html'
     context_object_name='todos'
 
+    def get_queryset(self):
+        status = self.request.GET.get('status', 'completed')
+
+        if status == 'all':
+            return Todo.objects.all()
+        elif status == 'not_completed':
+            return Todo.objects.filter(is_completed=False)
+        else:
+            return Todo.objects.filter(is_completed=True)
+
 class TodoCreate(CreateView):
     model=Todo
     fields = ["task_name", "task_description", "is_completed"]


### PR DESCRIPTION
### PR Description
This PR implements filtering functionality in the Todo list view, allowing users to filter the todos to view all tasks, only completed tasks, or only incomplete tasks.

**Summary**
- Added a filter query parameter to the TodoListView to filter todos by completion status.
- Updated the template to include selectbox for selecting the filter, with the default filter showing completed tasks.

**Testing**
User can filter the results by selecting status from selectbox below `Add todo`. After the selecting the status `All`, 'Completed', 'Not completed' and clicking the `Filter result button`. The filter on Todos will be applied and only filtered results will be shown.
- `All` - Shows all todos
- `Completed` - Shows only completed todos (status == 'Completed')
- `Not completed` - Shows only non completed todos (status == 'Not completed')