### PR TITLE
Add search capability for filtering todos by task name

### DIFF
--- a/app/templates/todo/list.html
+++ b/app/templates/todo/list.html
@@ -19,11 +19,11 @@
     <div>
     <hr>
     <form action="{% url 'todo_list' %}" method="get">
-        <input type="search" name="search" placeholder="Filter the results by name">
+        <input type="search" name="search" placeholder="Filter the results by name" value="{{ request.GET.search }}">
         <select name="status">
-            <option value="all">All</option>
-            <option value="completed" selected>Completed</option>
-            <option value="not_completed">Not Completed</option>
+            <option value="all" {% if request.GET.status == 'all' %} selected {% endif %}>All</option>
+            <option value="completed" {% if not request.GET.status == 'all' and not request.GET.status == 'non_completed' %} selected {% endif %}>Completed</option>
+            <option value="not_completed" {% if request.GET.status == 'not_completed' %} selected {% endif %}>Not Completed</option>
         </select>
         <button type="submit">Filter results</button>
     </form>

--- a/app/templates/todo/list.html
+++ b/app/templates/todo/list.html
@@ -19,6 +19,7 @@
     <div>
     <hr>
     <form action="{% url 'todo_list' %}" method="get">
+        <input type="search" name="search" placeholder="Filter the results by name">
         <select name="status">
             <option value="all">All</option>
             <option value="completed" selected>Completed</option>

--- a/app/tests.py
+++ b/app/tests.py
@@ -172,6 +172,34 @@ class TestTodoListViews(TestCase):
         self.assertNotContains(response, self.not_completed_task)
         self.assertContains(response, self.completed_task)
 
+    def test_todo_list_view_with_a_search_matching_any_todo_task_name(self):
+        task_not_in_matching_search = Todo.objects.create(
+            task_name='Todo 1',
+            task_description='Task 2 description',
+            is_completed=True
+        )
+
+        response = self.client.get(reverse('todo_list'), data={'status': 'all', 'search': 'Task'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.not_completed_task)
+        self.assertContains(response, self.completed_task)
+        self.assertNotContains(response, task_not_in_matching_search)
+
+    def test_todo_list_view_with_a_search_not_matching_any_todo_task_name(self):
+        response = self.client.get(reverse('todo_list'), data={'status': 'all', 'search': 'Todo'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, self.not_completed_task)
+        self.assertNotContains(response, self.completed_task)
+
+    def test_todo_list_view_with_a_search_not_matching_in_todo_task_name_filtered_by_status(self):
+        response = self.client.get(reverse('todo_list'), data={'status': 'completed', 'search': 'task 1'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, self.not_completed_task)
+        self.assertNotContains(response, self.completed_task)
+
 class TestTodoCreateViews(TestCase):
     def setUp(self):
         self.todo1 = Todo.objects.create(

--- a/app/views.py
+++ b/app/views.py
@@ -9,14 +9,18 @@ class TodoList(ListView):
 
     def get_queryset(self):
         status = self.request.GET.get('status', 'completed')
+        search = self.request.GET.get('search', '')
 
         if status == 'all':
-            return Todo.objects.all()
+            queryset = Todo.objects.all()
         elif status == 'not_completed':
-            return Todo.objects.filter(is_completed=False)
+            queryset = Todo.objects.filter(is_completed=False)
         else:
-            return Todo.objects.filter(is_completed=True)
+            queryset = Todo.objects.filter(is_completed=True)
 
+        if search:
+            queryset = queryset.filter(task_name__icontains=search)
+        return queryset
 class TodoCreate(CreateView):
     model=Todo
     fields = ["task_name", "task_description", "is_completed"]


### PR DESCRIPTION
### Summary
This PR enhances the todo list filtering by adding a search input that filters tasks based on the `task_name` field. Users can now type in the search box to narrow down the list of todos.

**Summary**
- Updated `TodoListView` to support filtering by the `search` query parameter using `icontains` for case insensitive match.
- Search works in combination with existing completion status filters.

This improves user experience by allowing quick access to specific tasks without manually scrolling through the list.

**Testing**
A new search input field is added beside `status` filter that allows users to filter todo items by `task name`, in addition to the existing status filter. Filtering is applied only when the user clicks the "Filter Results" button.
- If search field is empty - filter not applied on task name only the status filter will be applied.
- if search is not empty - filter will applied along the status filter on the todo list. search is partial and case insensitive match.
  `if search input  is 'T' and status filter is 'Completed'. It first filter results by completed and from those that are completed have 't' or 'T' in there name will be show in the list (Todo item with 't' or 'T' in task name but status is `Not completed` will not be shown)`