### PR TITLE
Add filter functionality to Todo ViewSet and implement filtering on frontend

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -2,6 +2,6 @@ from rest_framework.routers import DefaultRouter
 from .views import TodoViewSet
 
 router = DefaultRouter()
-router.register('todos', TodoViewSet)
+router.register('todos', TodoViewSet, basename='todo')
 
 urlpatterns = router.urls

--- a/app/views.py
+++ b/app/views.py
@@ -3,5 +3,19 @@ from .serializers import TodoSeralizer
 from .models import Todo
 
 class TodoViewSet(ModelViewSet):
-    queryset = Todo.objects.all()
     serializer_class = TodoSeralizer
+
+    def get_queryset(self):
+        status = self.request.query_params.get('status', '')
+        search = self.request.query_params.get('search', '')
+
+        if status == 'completed':
+            queryset = Todo.objects.filter(is_completed=True)
+        elif status == 'not-completed':
+            queryset = Todo.objects.filter(is_completed=False)
+        else:
+            queryset = Todo.objects.all()
+
+        if search:
+            queryset = queryset.filter(task_name__icontains=search)
+        return queryset

--- a/frontend/src/components/TodoList.jsx
+++ b/frontend/src/components/TodoList.jsx
@@ -8,12 +8,17 @@ const TodoList = () => {
     previous: null,
     results: []
   })
+  const [filter, setFilter] = useState({
+    search: '',
+    status: 'completed'
+  })
   const [error, setError] = useState('')
 
   useEffect(() => {
     const getTodos = async () => {
       try {
-        const response = await fetch('http://127.0.0.1:8000/api/v1/todos/', {
+        const response = await fetch(
+          `http://127.0.0.1:8000/api/v1/todos/?search=${filter.search}&status=${filter.status}`, {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
@@ -27,7 +32,7 @@ const TodoList = () => {
     }
 
     getTodos()
-  }, [])
+  }, [filter])
 
   const handlePagination = async (url) => {
     try {
@@ -48,6 +53,28 @@ const TodoList = () => {
     <div>
       <h1>Todo List</h1>
       <Link to='/todos/add'>Add Todo</Link>
+      <h3>Filter results</h3>
+      <div className='form-field-group'>
+        <label htmlFor='search'>Search</label>
+        <input
+          name='search'
+          value={filter.search}
+          onChange={(e) => setFilter({...filter, search: e.target.value})}
+          placeholder='Search by task name' />
+      </div>
+      <div className='form-field-group'>
+        <label htmlFor='status'>Status</label>
+        <select
+          name='status'
+          defaultValue='completed'
+          onChange={(e) => setFilter({...filter, status: e.target.value})}
+          >
+            <option value='all'>All</option>
+            <option value='completed'>Completed</option>
+            <option value='not-completed'>Not completed</option>
+        </select>
+      </div>
+      <hr />
       <hr />
       <div>Number of Todos found: {todos.count}</div>
       <hr />


### PR DESCRIPTION
### PR Description
This PR adds filtering logic to the `TodoViewSet` in the backend and connects it to the frontend for improved user interaction.

**Summary**
Backend:
  - Implemented custom filtering logic in `TodoViewSet` by overriding get_queryset method.
  - Supported filter parameters include:
    - `status`
    - `search`
  - Add `get_queryset` to reflect filtered results based on query parameters and remove `queryset` variable.
  - Add `basename` in urls for todos because we are using `get_queryset` instead of `queryset`.

Frontend:
  - Added UI controls (selectbox for status and input of search) for filter selection.
  - Connected UI filter state to API query parameters.
  - Updated `TodoList` component to re-fetch filtered todos on changing status or search.
  - Ensured real-time data updates without requiring a page reload.

**Testing**
User can filter todos by task name and by status. Note both filters will be applied to show todos.
```
If search field is empty - filter not applied on task name only the status filter will be applied.
if search is not empty - filter will applied along the status filter on the todo list. search is partial and case insensitive match.
    `if search input  is 'T' and status filter is 'Completed'. It first filter results by completed and from those that are completed have 't' or 'T' in there name will be show in the list (Todo item with 't' or 'T' in task name but status is `Not completed` will not be shown)`